### PR TITLE
Include hostname in application's uniqueid.

### DIFF
--- a/application/remote_assist_display/flask_config.py
+++ b/application/remote_assist_display/flask_config.py
@@ -1,5 +1,12 @@
-from environs import Env
+import socket
 import uuid
+
+from environs import Env
+
+
+def get_hostname() -> str:
+    """Return the device hostname."""
+    return socket.gethostname()
 
 
 def get_mac_address() -> str:
@@ -23,5 +30,9 @@ class Config(object):
     # The local storage key to use for the device name. By default, this is the
     # key used by browser_mod, to  maintain ViewAssist compatibility
     DEVICE_NAME_KEY = env.str("DEVICE_NAME_KEY", "browser_mod-browser-id")
+    # The device's MAC address
+    MAC_ADDRESS = env.str("MAC_ADDRESS", get_mac_address())
+    # The device's hostname
+    HOSTNAME = env.str("HOSTNAME", get_hostname())
     # The unique ID to use for this device
-    UNIQUE_ID = env.str("UNIQUE_ID", f"view-assist-display-{get_mac_address()}")
+    UNIQUE_ID = env.str("UNIQUE_ID", f"remote-assist-display-{MAC_ADDRESS}-{HOSTNAME}")

--- a/application/remote_assist_display/ha_websocket_manager.py
+++ b/application/remote_assist_display/ha_websocket_manager.py
@@ -122,7 +122,7 @@ class WebSocketManager:
 
         try:
             # Register the display
-            hostname = socket.gethostname()
+            hostname = self.app.config["HOSTNAME"]
             self.logger.debug(f"Hostname is: {hostname}")
             display_id = self.app.config["UNIQUE_ID"]
             self.logger.debug(f"Display ID is: {display_id}")

--- a/application/tests/conftest.py
+++ b/application/tests/conftest.py
@@ -13,7 +13,9 @@ def app():
     app = create_app()
     app.config["TESTING"] = True
     app.config["TOKEN_RETRY_LIMIT"] = 3
-    app.config["UNIQUE_ID"] = "test-device-id"
+    app.config["MAC_ADDRESS"] = "112233445566"
+    app.config["HOSTNAME"] = "test-hostname"
+    app.config["UNIQUE_ID"] = "remote-assist-display-112233445566-test-hostname"
 
     return app
 
@@ -111,6 +113,14 @@ def sample_config(temp_config_file):
     with open(temp_config_file, "w") as f:
         config.write(f)
     return config
+
+
+@pytest.fixture
+def mock_hostname():
+    """Mock socket.gethostname() to return a consistent value for testing."""
+    with patch("socket.gethostname") as mock:
+        mock.return_value = "test-hostname"
+        yield mock
 
 
 @pytest.fixture

--- a/application/tests/test_flask_config.py
+++ b/application/tests/test_flask_config.py
@@ -1,4 +1,10 @@
-from remote_assist_display.flask_config import get_mac_address
+from remote_assist_display.flask_config import get_hostname, get_mac_address
+
+
+def test_get_hostname(mock_hostname):
+    """Test hostname retrieval."""
+    hostname = get_hostname()
+    assert hostname == "test-hostname"
 
 
 def test_get_mac_address(mock_uuid_node):
@@ -7,3 +13,10 @@ def test_get_mac_address(mock_uuid_node):
     assert mac == "112233445566"
     assert len(mac) == 12
     int(mac, 16)  # Verify it's a valid hex string
+
+
+def test_config_values(app, mock_hostname, mock_uuid_node):
+    """Test that config values are set correctly."""
+    assert app.config["MAC_ADDRESS"] == "112233445566"
+    assert app.config["HOSTNAME"] == "test-hostname"
+    assert app.config["UNIQUE_ID"] == "remote-assist-display-112233445566-test-hostname"


### PR DESCRIPTION
This will make devices more easily identifiable,
while still maintaining the uniqueness.