### PR TITLE
13 ssl issues on android

### DIFF
--- a/application/Pipfile
+++ b/application/Pipfile
@@ -16,6 +16,7 @@ pytest-flask = "*"
 pytest-cov = "*"
 pytest-asyncio = "*"
 cython = "*"
+certifi = "*"
 
 [dev-packages]
 pyinstaller = "*"

--- a/application/Pipfile.lock
+++ b/application/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "72924da6cf8d2837531b2b68ab3f895e531365e9ec8db999ab344d328d955fba"
+            "sha256": "44f37d1ae94aa4c7d11ef7a76432d24a392512741a5d3b00d8b52dd9e8ced8b4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -150,6 +150,7 @@
                 "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
                 "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==2024.12.14"
         },

--- a/application/build/buildozer.spec
+++ b/application/build/buildozer.spec
@@ -7,7 +7,7 @@ title = Remote Assist Display
 package.name = RemoteAssistDisplay
 
 # (str) Package domain (needed for android/ios packaging)
-package.domain = com.caffeinatedfirefly.remoteassistdisplay
+package.domain = com.caffeinatedfirefly
 
 # (str) Source code where the main.py live
 source.dir = ../
@@ -37,7 +37,7 @@ version = 0.1
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy,pywebview,flask[async]==2.3.3,asgiref>=3.2,werkzeug==2.3.7,websockets,environs,requests,pillow,markupsafe==2.1.1,jinja2,itsdangerous,click,blinker,marshmallow,packaging,python-dotenv,proxy-tools,bottle,typing-extensions
+requirements = python3,certifi,kivy,pywebview,flask[async]==2.3.3,asgiref>=3.2,werkzeug==2.3.7,websockets,environs,requests,pillow,markupsafe==2.1.1,jinja2,itsdangerous,click,blinker,marshmallow,packaging,python-dotenv,proxy-tools,bottle,typing-extensions
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes


### PR DESCRIPTION
Use certifi for ssl context, which contains more up-to-date ssl certificates than the ssl library's. Resolves #13 .