### PR TITLE
Make android always log debug information

### DIFF
--- a/application/remote_assist_display/__init__.py
+++ b/application/remote_assist_display/__init__.py
@@ -12,6 +12,11 @@ def create_app():
     app.config.from_object(Config)
     app.debug = app.config['FLASK_DEBUG']
 
+    # Changing environment variables on andoroid is challenging, and we definitely
+    # want to see debug logs on android, so we'll set the log level to DEBUG
+    # if we are running on android.
+    if app.config['IS_ANDROID']:
+        app.config['LOG_LEVEL'] = 'DEBUG'
     log_level = getattr(logging, app.config['LOG_LEVEL'])
     
     logs_dir = os.path.join(os.path.dirname(__file__), '..', 'logs')

--- a/application/remote_assist_display/flask_config.py
+++ b/application/remote_assist_display/flask_config.py
@@ -8,7 +8,6 @@ def get_hostname() -> str:
     """Return the device hostname."""
     return socket.gethostname()
 
-
 def get_mac_address() -> str:
     """Return MAC address formatted as hex with no colons."""
     return "".join(
@@ -16,6 +15,12 @@ def get_mac_address() -> str:
             ::-1
         ]
     )
+
+def check_android(env: Env) -> bool:
+    """Check if we are running on an Android device."""
+    if bool(env.int("P4A_MINSDK", 0)):
+        return True
+    return False
 
 class Config(object):
     env = Env()
@@ -42,3 +47,5 @@ class Config(object):
     HOSTNAME = env.str("HOSTNAME", get_hostname())
     # The unique ID to use for this device
     UNIQUE_ID = env.str("UNIQUE_ID", f"remote-assist-display-{MAC_ADDRESS}-{HOSTNAME}")
+    # Are we running on android?
+    IS_ANDROID = check_android(env)


### PR DESCRIPTION
Setting environment variables on python for android is proving challenging, so for now, I'm turning on debug logs for all Android devices.