### PR TITLE
Allow token to be forcibly refreshed.

### DIFF
--- a/application/remote_assist_display/auth.py
+++ b/application/remote_assist_display/auth.py
@@ -1,6 +1,8 @@
-import webview
-import json
 import asyncio
+import json
+
+import webview
+
 
 class TokenStorage:
     _access_token = None
@@ -18,10 +20,13 @@ class TokenStorage:
         cls._access_token = None
 
 
-async def fetch_access_token(app, retries=5, delay=1, window=0, url=None):
-    token = TokenStorage.get_token()
-    if token:
-        return token
+async def fetch_access_token(app, retries=5, delay=1, window=0, url=None, force=False):
+    if force:
+        TokenStorage.clear_token()
+    else:
+        token = TokenStorage.get_token()
+        if token:
+            return token
 
     main_window = webview.windows[window]
 

--- a/application/remote_assist_display/ha_websocket_manager.py
+++ b/application/remote_assist_display/ha_websocket_manager.py
@@ -1,7 +1,10 @@
 import asyncio
 import socket
 import threading
+from operator import ge
 from typing import Optional
+
+from flask import g
 
 from .auth import fetch_access_token
 from .home_assistant_ws_client import HomeAssistantWebSocketClient
@@ -113,6 +116,11 @@ class WebSocketManager:
                 self.logger.error(
                     f"Error in connection monitor: {str(e)}", exc_info=True
                 )
+                if "Authentication failed" in str(e):
+                    # Force a re-authentication
+                    self.logger.warning("Forcing re-authentication")
+                    self.token = await fetch_access_token(url=self.ws_url, app=self.app, force=True)
+
                 await asyncio.sleep(5)  # Wait before retrying
 
     async def register(self):

--- a/application/tests/test_auth.py
+++ b/application/tests/test_auth.py
@@ -1,6 +1,9 @@
 import json
+
 import pytest
+
 from remote_assist_display.auth import TokenStorage, fetch_access_token
+
 
 class TestTokenStorage:
     def test_set_and_get_token(self):
@@ -128,3 +131,23 @@ class TestFetchAccessToken:
 
         with pytest.raises(Exception):
             await fetch_access_token(app, retries=1)
+
+    @pytest.mark.asyncio
+    async def test_fetch_token_force_flag(self, mock_webview, app):
+        """Test force flag clears storage and fetches new token."""
+        mock_wv, mock_window = mock_webview
+        
+        # Set initial token
+        initial_token = "initial-token"
+        TokenStorage.set_token(initial_token)
+        
+        # Mock new token response
+        new_token = "new-token-789"
+        mock_window.evaluate_js.return_value = json.dumps({"access_token": new_token})
+
+        # Fetch with force=True
+        token = await fetch_access_token(app, force=True)
+        
+        # Verify storage was cleared and new token was fetched
+        assert token == new_token
+        mock_window.evaluate_js.assert_called_once()


### PR DESCRIPTION
Forcibly refresh the token when websocket authentication fails. This was happening after a server reboot, because the prior token was invalidated.