### PR TITLE
Save unique id to config file

### DIFF
--- a/application/remote_assist_display/__init__.py
+++ b/application/remote_assist_display/__init__.py
@@ -8,6 +8,7 @@ from flask import Flask
 
 from .flask_config import Config
 
+
 class TokenMaskingFilter(logging.Filter):
     # Match any JWT token format (three base64url-encoded sections separated by dots)
     JWT_PATTERN = r'([a-zA-Z0-9_-]+\.){2}[a-zA-Z0-9_-]+'
@@ -60,7 +61,7 @@ def create_app():
     app.logger.info("=" * 80)
     app.logger.info(f"Remote Assist Display v{app.config['VERSION']}")
     app.logger.info("-" * 80)
-    app.logger.info(f"Unique ID: {app.config['UNIQUE_ID']}")
+    app.logger.info(f"Detected Unique ID: {app.config['UNIQUE_ID']}")
     app.logger.info(f"Running on Android: {app.config['IS_ANDROID']}")
     app.logger.info(f"Frozen executable: {app.config['IS_FROZEN']}")
     app.logger.info(f"Log dir.: {logs_dir}")

--- a/application/remote_assist_display/routes.py
+++ b/application/remote_assist_display/routes.py
@@ -23,6 +23,23 @@ def register_routes(app):
             current_app.config["url"] = saved_config.get(
                 "HomeAssistant", "url", fallback=None
             )
+            last_id = saved_config.get("HomeAssistant", "unique_id", fallback=None)
+            if last_id and last_id not in current_app.config["UNIQUE_ID"]:
+                current_app.logger.debug(
+                    "Last used ID %s does not match current device's ID %s, using previous ID instead.",
+                    last_id,
+                    current_app.config["UNIQUE_ID"],
+                )
+                current_app.config["UNIQUE_ID"] = last_id
+            else:
+                save_to_config(
+                    "HomeAssistant",
+                    "unique_id",
+                    current_app.config["UNIQUE_ID"], 
+                    current_app.config["CONFIG_DIR"]
+                )
+                
+
             current_app.logger.debug(f"Found configured URL: {current_app.config['url']}")
             if current_app.config["url"]:
                 # Todo: handle cases where we have a saved url, but no valid credentials
@@ -111,6 +128,13 @@ def register_routes(app):
                 return "", HTTPStatus.OK  # Return OK since we handled the navigation
             # Save the URL to our config file
             save_url(url)
+            # Save the unique ID to our config file
+            save_to_config(
+                "HomeAssistant",
+                "unique_id",
+                current_app.config["UNIQUE_ID"],
+                current_app.config["CONFIG_DIR"]
+            )
             current_app.logger.debug("Redirecting to waiting page")
             await load_dashboard(url_for("waiting"), local_storage=False)
             return "", HTTPStatus.OK

--- a/application/remote_assist_display/routes.py
+++ b/application/remote_assist_display/routes.py
@@ -24,7 +24,7 @@ def register_routes(app):
                 "HomeAssistant", "url", fallback=None
             )
             last_id = saved_config.get("HomeAssistant", "unique_id", fallback=None)
-            if last_id and last_id not in current_app.config["UNIQUE_ID"]:
+            if last_id and last_id != current_app.config["UNIQUE_ID"]:
                 current_app.logger.debug(
                     "Last used ID %s does not match current device's ID %s, using previous ID instead.",
                     last_id,

--- a/application/tests/test_routes.py
+++ b/application/tests/test_routes.py
@@ -1,12 +1,10 @@
 # test_routes.py
 from configparser import ConfigParser
 from http import HTTPStatus
-
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 import requests
-
 
 
 def test_config_no_saved_url(client, mock_get_saved_config):
@@ -57,7 +55,11 @@ async def test_connect_success(
     mock_fetch_access_token.assert_called_once_with(
         app=app, url=test_url, retries=app.config["TOKEN_RETRY_LIMIT"], delay=10
     )
-    mock_save_to_config.assert_called_once_with("HomeAssistant", "url", test_url, "/tmp")
+    assert mock_save_to_config.call_count == 2
+    mock_save_to_config.assert_has_calls([
+        call("HomeAssistant", "url", test_url, "/tmp"),
+        call("HomeAssistant", "unique_id", "remote-assist-display-112233445566-test-hostname", "/tmp")
+    ])
     assert mock_load_dashboard.call_count == 2
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Remote Assist Display creates unique IDs for Home Assistant based on the device's MAC address.  Many Android devices, however, either have MAC address randomization turned on, or don't reliably report the correct MAC address.  This change saves the created unique ID to the config file, and uses the previous one if a new mac address is detected, preventing duplicate entries in Home Assistant. Note that the detected MAC address is still logged at startup, as the config file is not yet available at that point. If a different unique ID is set, a message is logged with both the previous and ignored unique id.